### PR TITLE
feat(IStakedAave): add getTotalRewardsBalance

### DIFF
--- a/contracts/interfaces/IStakedAave.sol
+++ b/contracts/interfaces/IStakedAave.sol
@@ -9,4 +9,6 @@ interface IStakedAave {
   function cooldown() external;
 
   function claimRewards(address to, uint256 amount) external;
+
+  function getTotalRewardsBalance(address staker) external view returns (uint256);
 }


### PR DESCRIPTION
I've added the `getTotalRewardsBalance` function that was missing from the Staked Aave interface.